### PR TITLE
Fixed old IE-style getter of event.

### DIFF
--- a/common.blocks/pt-surface/pt-surface.js
+++ b/common.blocks/pt-surface/pt-surface.js
@@ -1,12 +1,12 @@
-$('.pt-surface__action').on('click', function(){
-	showPopup();
+$('.pt-surface__action').on('click', function(e){
+	showPopup(e);
 });
 
 $('.pt-surface__close').on('click', function(){
 	hidePopup();
 });
 
-function showPopup() {
+function showPopup(event) {
 	var attribute = $(event.target.attributes['data-name']).val();
 
 	$("div#"+attribute).fadeIn(220);


### PR DESCRIPTION
На данный момент глобальное свойство `window.event`  [не поддерживается](https://developer.mozilla.org/en-US/docs/Web/API/Window/event) браузером Firefox.
К примеру, вероятно, по этой причине на сайте [bem.design](http://bem.design) в Firefox не работает боковое меню.